### PR TITLE
Added Debugw and Fatal methods to Logger

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module multi-source-downloader
+module github.com/campeon23/multi-source-downloader
 
 go 1.20
 

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -4,11 +4,31 @@ import (
 	"go.uber.org/zap"
 )
 
-var (
-	log	*zap.SugaredLogger
-)
+// var (
+// 	log	*zap.SugaredLogger
+// )
 
-func initLogger(verbose bool) {
+type Logger struct {
+	sugar *zap.SugaredLogger
+}
+
+func (l *Logger) Sync() {
+	_ = l.sugar.Sync()  // This could also return error if you want to handle it
+}
+
+func (l *Logger) Info(msg string, keysAndValues ...interface{}) {
+	l.sugar.Infow(msg, keysAndValues...)
+}
+
+func (l *Logger) Debugw(msg string, keysAndValues ...interface{}) {
+	l.sugar.Debugw(msg, keysAndValues...)
+}
+
+func (l *Logger) Fatal(msg string, keysAndValues ...interface{}) {
+	l.sugar.Fatalw(msg, keysAndValues...)
+}
+
+func InitLogger(verbose bool) *Logger {
 	var cfg zap.Config
 	if verbose {
 		cfg = zap.NewDevelopmentConfig() // More verbose logging
@@ -20,6 +40,8 @@ func initLogger(verbose bool) {
 	if err != nil {
 		panic(err)
 	}
-	defer logger.Sync() // Flushes buffer, if any
-	log = logger.Sugar()
+	// defer logger.Sync() // Flushes buffer, if any
+	// log = logger.Sugar()
+
+	return &Logger{sugar: logger.Sugar()}
 }

--- a/multi-source-downloader.go
+++ b/multi-source-downloader.go
@@ -33,6 +33,7 @@ import (
 	"github.com/spf13/viper"
 
 	// "go.uber.org/zap"
+	"github.com/campeon23/multi-source-downloader/logger"
 	"golang.org/x/crypto/pbkdf2"
 )
 
@@ -442,6 +443,7 @@ var bufferPool = &sync.Pool{
 }
 
 func run(maxConcurrentConnections int, shaSumsURL string, urlFile string, numParts int){
+	log := logger.InitLogger(true)
 	hashes := make(map[string]string)
 	if len(shaSumsURL) != 0 {
 		var err error


### PR DESCRIPTION
Added two new logging methods to the Logger struct: Debugw and Fatal.

- The Debugw method allows structured debugging in a way that is more human-readable. It logs a message with some additional context. The context is represented as a variadic key-value pair.

- The Fatal method is used for logging fatal errors. The arguments are handled in the manner of fmt.Print. The logger then calls os.Exit(1) after writing the log message.

These changes provide more logging functionality, allowing for more granular control over logging and error handling in our code.