### PR TITLE
Fix issues with shaSumsURL and logger initialization

### DIFF
--- a/encryption/encryption.go
+++ b/encryption/encryption.go
@@ -11,10 +11,21 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/campeon23/multi-source-downloader/logger"
 	"golang.org/x/crypto/pbkdf2"
 )
 
-func createEncryptionKey(strings []string) ([]byte, error) {
+type Encryption struct {
+	Log	*logger.Logger
+}
+
+func NewEncryption(log *logger.Logger) *Encryption {
+	return &Encryption{
+		Log: log,
+	}
+}
+
+func CreateEncryptionKey(strings []string) ([]byte, error) {
 	// Sort the strings in reverse order
 	sort.Sort(sort.Reverse(sort.StringSlice(strings)))
 
@@ -32,8 +43,8 @@ func createEncryptionKey(strings []string) ([]byte, error) {
 }
 
 // encryptFile encrypts the file with the given key and writes the encrypted data to a new file
-func encryptFile(filename string, key []byte) error {
-	log.Info("Initializing ecryption of manifest file.")
+func (e *Encryption) EncryptFile(filename string, key []byte) error {
+	e.Log.Infow("Initializing ecryption of manifest file.")
 	plaintext, err := os.ReadFile(filename)
 	if err != nil {
 		return err
@@ -71,19 +82,19 @@ func encryptFile(filename string, key []byte) error {
 	encryptedFile.Write(iv)
 	encryptedFile.Write(ciphertext)
 
-	log.Debugw("File encrypted successfully and saved as:", 
+	e.Log.Debugw("File encrypted successfully and saved as:", 
 		"encryptedFilename", encryptedFilename,
 	)
 
 	err = os.Remove(filename)
 	if err != nil {
-		log.Fatal(err)
+		e.Log.Fatal("Cannot remove encrypted file:", "error", err.Error())
 	}
 
 	return nil
 }
 
-func decryptFile(encryptedFilename string, key []byte, toDisk bool) ([]byte, error) {
+func (e *Encryption) DecryptFile(encryptedFilename string, key []byte, toDisk bool) ([]byte, error) {
 	encryptedFile, err := os.Open(encryptedFilename)
 	if err != nil {
 		return nil, err
@@ -126,7 +137,7 @@ func decryptFile(encryptedFilename string, key []byte, toDisk bool) ([]byte, err
 			return nil, err
 		}
 
-		log.Debugw("File decrypted successfully and saved as:",
+		e.Log.Debugw("File decrypted successfully and saved as:",
 			"decryptedFilename", decryptedFilename,
 		)
 

--- a/fileutils/fileutils.go
+++ b/fileutils/fileutils.go
@@ -2,7 +2,7 @@ package fileutils
 
 import "os"
 
-func pathExists(path string) bool {
+func PathExists(path string) bool {
     _, err := os.Stat(path)
     return !os.IsNotExist(err)
 }

--- a/go.sum
+++ b/go.sum
@@ -39,6 +39,7 @@ dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=
+github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
@@ -198,6 +199,7 @@ go.uber.org/atomic v1.7.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
 go.uber.org/atomic v1.9.0 h1:ECmE8Bn/WFTYwEW/bpKD3M8VtR/zQVbavAoalC1PYyE=
 go.uber.org/atomic v1.9.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
 go.uber.org/goleak v1.1.11 h1:wy28qYRKZgnJTxGxvye5/wgWr1EKjmUDGYox5mGlRlI=
+go.uber.org/goleak v1.1.11/go.mod h1:cwTWslyiVhfpKIDGSZEM2HlOvcqm+tG4zioyIeLoqMQ=
 go.uber.org/multierr v1.8.0 h1:dg6GjLku4EH+249NNmoIciG9N/jURbDG+pFlTkhzIC8=
 go.uber.org/multierr v1.8.0/go.mod h1:7EAYxJLBy9rStEaz58O2t4Uvip6FSURkq8/ppBp95ak=
 go.uber.org/zap v1.24.0 h1:FiJd5l1UOLj0wCgbSE0rwwXHzEdAZS6hiiSnxJN/D60=

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -4,10 +4,6 @@ import (
 	"go.uber.org/zap"
 )
 
-// var (
-// 	log	*zap.SugaredLogger
-// )
-
 type Logger struct {
 	sugar *zap.SugaredLogger
 }
@@ -16,12 +12,16 @@ func (l *Logger) Sync() {
 	_ = l.sugar.Sync()  // This could also return error if you want to handle it
 }
 
-func (l *Logger) Info(msg string, keysAndValues ...interface{}) {
+func (l *Logger) Infow(msg string, keysAndValues ...interface{}) {
 	l.sugar.Infow(msg, keysAndValues...)
 }
 
 func (l *Logger) Debugw(msg string, keysAndValues ...interface{}) {
 	l.sugar.Debugw(msg, keysAndValues...)
+}
+
+func (l *Logger) Warnw(msg string, keysAndValues ...interface{}) {
+	l.sugar.Warnw(msg, keysAndValues...)
 }
 
 func (l *Logger) Fatal(msg string, keysAndValues ...interface{}) {
@@ -40,8 +40,6 @@ func InitLogger(verbose bool) *Logger {
 	if err != nil {
 		panic(err)
 	}
-	// defer logger.Sync() // Flushes buffer, if any
-	// log = logger.Sugar()
 
 	return &Logger{sugar: logger.Sugar()}
 }


### PR DESCRIPTION
In this commit, we have addressed two key issues that were causing problems in the code execution.

- Firstly, we noticed that the variable shaSumsURL in the hasher package was not being initialized or set before its usage in the DownloadAndParseHashFile function. This was causing the function to fail due to an empty string, leading to an error about an unsupported protocol scheme. This has been resolved by passing shaSumsURL as a parameter to the function where it's being used.

- Secondly, we identified that the logger object, which was initialized in the main function, was not the same logger object being used in other packages. This was due to the separate definitions of the logger object in different packages, causing them to be treated as different variables. To solve this, we have modified the hasher package to accept a logger as a parameter, thus ensuring consistency across all usages of the logger.