### PR TITLE
Refactor: Encapsulate Parameters within Downloader Constructor

### DIFF
--- a/multi-source-downloader.go
+++ b/multi-source-downloader.go
@@ -110,7 +110,7 @@ func processPartsDir() {
 
 func run(maxConcurrentConnections int, shaSumsURL string, urlFile string, numParts int, partsDir string, keepParts bool){
 	a := assembler.NewAssembler(partsDir, log)
-	d := downloader.NewDownloader(partsDir, log)
+	d := downloader.NewDownloader(urlFile, numParts, maxConcurrentConnections, partsDir, log)
 	e := encryption.NewEncryption(log)
 	h := hasher.NewHasher(log)
 	m := manifest.NewManifest(log)
@@ -135,7 +135,7 @@ func run(maxConcurrentConnections int, shaSumsURL string, urlFile string, numPar
 		log.Fatal("URL is required")
 	}
 
-	downloadManifest, partFilesHashes, size, etag, hashType, rangeSize, fileName := d.DownloadPartFiles(urlFile, numParts, maxConcurrentConnections)
+	downloadManifest, partFilesHashes, size, etag, hashType, rangeSize, fileName := d.DownloadPartFiles()
 
 	// Create the final file we want to assemble
 	outFile, err := os.Create(fileName)


### PR DESCRIPTION
- In a move towards better encapsulation and easier function calls, I've changed how parameters are passed to the downloader package. Rather than passing flags as parameters directly to the DownloadPartFiles function, these are now made available via the NewDownloader constructor method.

This design choice not only simplifies function calls but also improves code clarity and encapsulation.