### PR TITLE
Refactor BufferPool to Use Byte Pointer for Enhanced Performance

### DIFF
--- a/downloader/downloader.go
+++ b/downloader/downloader.go
@@ -180,7 +180,7 @@ func (d *Downloader) DownloadPart(client *http.Client, i, rangeSize, size int, s
 		}
 		defer resp.Body.Close()
 
-		buf := utils.BufferPool.Get().([]byte) // Get a buffer from the pool
+		buf := utils.BufferPool.Get().(*[]byte) // Get a buffer from the pool
 		defer func() { 
 			utils.BufferPool.Put(buf) 
 		}() // Return the buffer to the pool when done
@@ -199,10 +199,10 @@ func (d *Downloader) DownloadPart(client *http.Client, i, rangeSize, size int, s
 		startTime := time.Now() // record start time of reading chunk
 		for {
 			// read a chunk
-			bytesRead, err := reader.Read(buf)
+			bytesRead, err := reader.Read(*buf)
 			if bytesRead > 0 {
 				// write a chunk
-				_, err := writer.Write(buf[:bytesRead])
+				_, err := writer.Write((*buf)[:bytesRead])
 				if err != nil {
 					d.Log.Fatalw("Error: Failed to write a chunk: ", "error", err)
 				}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -13,7 +13,8 @@ import (
 // Define a buffer pool globally to reuse buffers
 var BufferPool = &sync.Pool{
 	New: func() interface{} {
-		return make([]byte, 4096) // Fixed buffer size for efficient memory usage
+		b := make([]byte, 4096) // Fixed buffer size for efficient memory usage
+		return &b
 	},
 }
 


### PR DESCRIPTION
Optimized the BufferPool implementation:

- Addressed a longstanding warning by adjusting the BufferPool's New function to return a pointer to a byte slice (*[]byte) instead of the byte slice itself.

- This change promotes better memory management and performance by preventing unnecessary memory allocations and copying.

- This refinement aligns our codebase more closely with Go best practices, ensuring better predictability, memory efficiency, and overall code health.