### PR TITLE
Fix Elapsed Time Display in Progress Bar

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -36,9 +36,12 @@ type ProgressWriter struct {
 }
 
 func (pw *ProgressWriter) Write(p []byte) (int, error) {
-	n := len(p)
-	pw.Bar.Set(pw.Bar.Current() + n)
-	return pw.W.Write(p)
+	// n := len(p)
+	// pw.Bar.Set(pw.Bar.Current() + n)
+	// return pw.W.Write(p)
+	n, err := pw.W.Write(p)
+	pw.Bar.Incr()
+	return n, err
 }
 
 func FormatFileSize(bytes int64) string {


### PR DESCRIPTION
Improved Progress Bar's elapsed time display:

- Addressed an oversight in the initial progress bar implementation where the elapsed time was not being displayed.

- Identified the root cause in the  function: even though the bar was set, the writer was not incrementing, preventing the calculation of elapsed time.

- Referenced the application's support guide and made necessary adjustments to align with the recommended documentation.

- This enhancement not only resolves the display issue but also enriches the progress bar by providing additional useful information to the user.