### PR TITLE
Rename .goreleaser.yml to .slsa-goreleaser.yml

### DIFF
--- a/.slsa-goreleaser.yml
+++ b/.slsa-goreleaser.yml
@@ -1,0 +1,57 @@
+# This is an example .goreleaser.yml file with some sensible defaults.
+# Make sure to check the documentation at https://goreleaser.com
+before:
+  hooks:
+    # You may remove this if you don't use go modules.
+    - go mod tidy
+    # you may remove this if you don't need go generate
+    - go generate ./...
+builds:
+  - env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - windows
+      - darwin
+#Configuration for building packages for rpm and deb package managers
+nfpms:
+  - package_name: shagen
+    homepage: https://github.com/rexfordnyrk/shagen/
+    maintainer: Rexford A. Nyarko <rexfordnyrk@gmail.com>
+    description: |-
+            Shagen installer package. CLI application to generate SHA256 hashes of texts.
+    formats:
+      - rpm
+      - deb
+sboms:
+  - artifacts: archive
+
+archives:
+  - format: tar.gz
+    # this name template makes the OS and Arch compatible with the results of uname.
+    name_template: >-
+      {{ .ProjectName }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+      {{- if .Arm }}v{{ .Arm }}{{ end }}
+    # use zip for windows archives
+    format_overrides:
+    - goos: windows
+      format: zip
+checksum:
+  name_template: 'checksums.txt'
+snapshot:
+  name_template: "{{ incpatch .Version }}-next"
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - '^docs:'
+      - '^test:'
+
+# The lines beneath this are called `modelines`. See `:help modeline`
+# Feel free to remove those if you don't want/use them.
+# yaml-language-server: $schema=https://goreleaser.com/static/schema.json
+# vim: set ts=2 sw=2 tw=0 fo=cnqoj


### PR DESCRIPTION
- Resolved a file not found error by renaming the .goreleaser.yml file to .slsa-goreleaser.yml. This change aligns with the expected file name and ensures smooth processing during the build.