### PR TITLE
Replace enablePprof check with keepParts condition for manifest decry…

### DIFF
--- a/multi-source-downloader.go
+++ b/multi-source-downloader.go
@@ -147,7 +147,7 @@ func run(maxConcurrentConnections int, shaSumsURL string, urlFile string, numPar
 		log.Fatalf("Decrypting manifest file: %w", err)
 	}
 
-	if enablePprof {
+	if keepParts {
 		// Dump the decrypted content to a JSON file
 		err = os.WriteFile(manifestPath, decryptedContent, 0644)
 		if err != nil {


### PR DESCRIPTION
…ption

Removed the condition that previously checked for . Introduced a new condition to check if  is set to true. When  is true, the process will proceed to decrypt the manifest. This change streamlines the conditionals and ensures the right checks are in place before manifest decryption.