### PR TITLE
Checked error returned from f.EnsureAppRoot()

### DIFF
--- a/multi-source-downloader.go
+++ b/multi-source-downloader.go
@@ -134,7 +134,10 @@ func run(maxConcurrentConnections int, shaSumsURL string, urlFile string, numPar
 	h := hasher.NewHasher(partsDir, prefixParts, log)
 	u := utils.NewUtils(partsDir, log)
 
-	appRoot, _ := f.EnsureAppRoot()
+	appRoot, err := f.EnsureAppRoot()
+	if err != nil {
+		log.Fatalf("Failed to validate current app root: %w", err)
+	}
 
 	_, hashes, manifestPath, key, size, rangeSize, etag, hashType, err := d.Download(shaSumsURL, partsDir, prefixParts, urlFile, downloadOnly, outputFile)
 	if err != nil {


### PR DESCRIPTION
Addressed a missed error handling instance by checking the error returned from the function `f.EnsureAppRoot()`.

Note: It's crucial to ensure that every error is adequately caught to maintain the robustness of this application.