### PR TITLE
Disable GO111MODULE in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,22 +30,24 @@ jobs:
         run: |
           curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh | sh -s -- -b /usr/local/bin
       
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.21
+        env:
+          GO111MODULE: off
+
       # Install golangci-lint
       - name: Install golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
           version: latest
           only-new-issues: false
-          
-      - name: Set up Go
-        uses: actions/setup-go@v2
-        with:
-          go-version: 1.21
 
-      # # Install gopls
-      # - name: Install gopls
-      #   run: |
-      #     go install golang.org/x/tools/gopls@latest
+      # Install gopls
+      - name: Install gopls
+        run: |
+          go install golang.org/x/tools/gopls@latest
           
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -10,13 +10,13 @@ before:
     - go mod download
     - go generate ./...
     - golangci-lint run ./...
-    # - gopls vulncheck ./...
-    # - gopls check ./*/*/*.go
-    # - gopls check ./*/*.go
-    # - gopls check ./*.go
-    # - gopls -rpc.trace -v check ./*/*/*.*
-    # - gopls -rpc.trace -v check ./*/*.*
-    # - gopls -rpc.trace -v check ./*.*
+    - gopls vulncheck ./...
+    - gopls check ./*/*/*.go
+    - gopls check ./*/*.go
+    - gopls check ./*.go
+    - gopls -rpc.trace -v check ./*/*/*.*
+    - gopls -rpc.trace -v check ./*/*.*
+    - gopls -rpc.trace -v check ./*.*
     - go test ./...
     - go test -cover ./...
 builds:


### PR DESCRIPTION
Updated the release.yml workflow by turning off the GO111MODULE during the Go setup. This is to ensure compatibility with non-module projects and dependencies.