### PR TITLE
Add permissions for jq installation in docker build environment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
       # Install jq
       - name: Install jq
         run: |
-          apt-get update && apt-get install -y jq
+          sudo apt-get update && sudo apt-get install -y jq
     
       - name: Set up Go
         uses: actions/setup-go@v2


### PR DESCRIPTION
- Ensured adequate permissions to successfully install jq from the release.yml within the docker build environment.