### PR TITLE
Refactor: Remove redundant fmt.Println() and update README features

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,15 @@ Flags:
   -k, --keep-parts             // (Optional) Whether to keep the parts files after assembly
   -m, --manifest-file string   // (Required by --assemble-only) Manifest file (must be decrypted) to pass to the main function
   -c, --max-connections int    // (Optional) Controls how many parts of the file are downloaded at the same time.
+                               // You can set a specific number, or if you set it to 0, it will choose the maximum
+                               // concurrent connections, equal to the number of chunk parts to split the file.
   -n, --num-parts int          // (Optional) Number of parts to split the download into (default 5)
   -o, --output string          // (Optional) Name and location of the final output file
   -p, --parts-dir string       // (Optional) The directory to save the parts files
   -x, --prefix-parts string    // (Optional) The prefix to use for naming the parts files (default "output-")
-  -s, --sha-sums string        // (Optional) The URL of the file containing the hashes.
+  -r, --proxy string           // (Optional) Proxy to use for the download
+  -s, --sha-sums string        // (Optional) The URL of the file containing the hashes refers to a file with either MD5 or
+                               // SHA-256 hashes, used to verify the integrity and  authenticity of the downloaded file.
   -u, --url string             // (Required) URL of the file to download
   -v, --verbose                // (Optional) Output verbose logging (INFO and Debug), verbose not passed only output INFO logging.
 ```

--- a/downloader/downloader.go
+++ b/downloader/downloader.go
@@ -661,8 +661,6 @@ func (d *Downloader) HandleEncryption(m *manifest.Manifest, e *encryption.Encryp
 		return nil, "", fmt.Errorf("failed to obtain the path of the downloaded manifest: %w", err)
 	}
 
-	fmt.Print("manifestPath: ", manifestPath, "\n")
-
 	key, err := e.CreateEncryptionKey(manifestPath, partFilesHashes, true)
 	if err != nil {
 		return nil, "", fmt.Errorf("failed to obtain the encryption key: %w", err)

--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -75,7 +75,7 @@ func (m *Manifest) GetDownloadManifestPath(fileName string, hash string) (string
 		path = filepath.Join(os.Getenv("HOME"), ".config", ".multi-source-downloader")
 	}
 
-	return filepath.Join(path, fileName+".manifest." + hash + "-" + strconv.FormatInt(m.TimeStamp, 10) + ".json"), nil
+	return filepath.Join(path, fileName + "-manifest-" + hash + "-" + strconv.FormatInt(m.TimeStamp, 10) + ".json"), nil
 }
 
 func (m *Manifest) SaveDownloadManifest(manifest DownloadManifest, fileName string, hash string) error {

--- a/multi-source-downloader.go
+++ b/multi-source-downloader.go
@@ -118,17 +118,15 @@ func init() {
 		dbcfg.InitConfig(dbcfg.ViperInstance)
 	})
 	// Initialize the Flags struct
-	rootCmd.PersistentFlags().IntVarP(&appcfg.MaxConcurrentConnections, flags.MaxConcurrentConnections, "c", 0, `(Optional) Controls how many parts of the 
-file are downloaded at the same time. You can set a specific number, 
-or if you set it to 0, it will choose the maximum concurrenct connections,
-equal to the number of chunk parts to split the file.`)
-	rootCmd.PersistentFlags().StringVarP(&appcfg.ShaSumsURL, 	flags.ShaSumsURL, 	 	"s", "", 		`(Optional) The URL of the file containing the hashes refers to a file 
-with either MD5 or SHA-256 hashes, used to verify the integrity and 
-authenticity of the downloaded file.`)
+	rootCmd.PersistentFlags().IntVarP(&appcfg.MaxConcurrentConnections, flags.MaxConcurrentConnections, "c", 0, `(Optional) Controls how many parts of the file are downloaded at the same time. 
+You can set a specific number, or if you set it to 0, it will choose the maximum 
+concurrent connections, equal to the number of chunk parts to split the file.`)
+	rootCmd.PersistentFlags().StringVarP(&appcfg.ShaSumsURL, 	flags.ShaSumsURL, 	 	"s", "", 		`(Optional) The URL of the file containing the hashes refers to a file with either MD5 or 
+SHA-256 hashes, used to verify the integrity and  authenticity of the downloaded file.`)
 	rootCmd.PersistentFlags().StringVarP(&appcfg.UrlFile, 		flags.UrlFile, 			"u", "",		"(Required) URL of the file to download")
 	rootCmd.PersistentFlags().IntVarP(&appcfg.NumParts, 		flags.NumParts, 	 	"n", 2, 	 	"(Optional) Number of parts to split the download into. Default value is 2")
 	rootCmd.PersistentFlags().StringVarP(&appcfg.PartsDir, 		flags.PartsDir, 	  	"p", "", 	 	"(Optional) The directory to save the parts files")
-	rootCmd.PersistentFlags().StringVarP(&appcfg.PrefixParts, 	flags.PrefixParts, 	 	"x", "output", "(Optional) The prefix to use for naming the parts files")
+	rootCmd.PersistentFlags().StringVarP(&appcfg.PrefixParts, 	flags.PrefixParts, 	 	"x", "output",	"(Optional) The prefix to use for naming the parts files")
 	rootCmd.PersistentFlags().StringVarP(&appcfg.Proxy, 		flags.Proxy, 		 	"r", "", 	 	"(Optional) Proxy to use for the download")
 	rootCmd.PersistentFlags().BoolVarP(&appcfg.KeepParts, 		flags.KeepParts, 	 	"k", false, 	"(Optional) Whether to keep the parts files after assembly")
 	rootCmd.PersistentFlags().BoolVarP(&appcfg.DecryptManifest,flags.DecryptManifest,	"f", false, 	"(Optional) If true, decrypt the manifest file")
@@ -136,7 +134,7 @@ authenticity of the downloaded file.`)
     rootCmd.PersistentFlags().BoolVarP(&appcfg.DownloadOnly, 	flags.DownloadOnly, 	"d", false, 	"(Optional) Download part files only if true")
     rootCmd.PersistentFlags().BoolVarP(&appcfg.AssembleOnly, 	flags.AssembleOnly, 	"a", false, 	"(Optional) Assemble part files only if true and --parts-dir and --manifest flags are passed")
     rootCmd.PersistentFlags().StringVarP(&appcfg.OutputFile, 	flags.OutputFile,		"o", "", 		"(Optional) Name and location of the final output file")
-	rootCmd.PersistentFlags().BoolVarP(&appcfg.Verbose,		flags.Verbose, 		 	"v", false, 	`(Optional) Output verbose logging (INFO and Debug), verbose not passed
+	rootCmd.PersistentFlags().BoolVarP(&appcfg.Verbose,			flags.Verbose, 		 	"v", false, 	`(Optional) Output verbose logging (INFO and Debug), verbose not passed
 only output INFO logging.`)
 	rootCmd.PersistentFlags().BoolVarP(&ppcfg.EnablePprof, 	flags.EnablePprof,  	"e", false, 	"Enable pprof profiling. This parameter will only work, if a pprof configuration file exits.")
 	appcfg.BindFlagToViper(flags.MaxConcurrentConnections, appcfg.Log)

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -154,6 +154,5 @@ func (u *Utils) ExtractTimestampFromFilename(filename string) (int64, error) {
 		return 0, fmt.Errorf("failed to parse timestamp: %w", err)
 	}
 
-	fmt.Printf("timestamp from encrypted manifest: %d\n", timestamp)
 	return timestamp, nil
 }


### PR DESCRIPTION
- Removed unnecessary fmt.Println() comments from the codebase, enhancing code clarity.

- Updated the README.md file to highlight new features, including the proxy flag.