### PR TITLE
Refactor File Encryption and Manifest Logic

### DIFF
--- a/downloader/downloader.go
+++ b/downloader/downloader.go
@@ -656,7 +656,7 @@ func (d *Downloader) ManifestObject(m *manifest.Manifest, downloadManifest manif
 
 func (d *Downloader) HandleEncryption(m *manifest.Manifest, e *encryption.Encryption, f *fileutils.Fileutils, contentData []byte, partFilesHashes []string, fileName string, hash string) ([]byte, string, error) {
 	d.Log.Debugw("Handling encrypted manifest file")
-	manifestPath, err := m.GetDownloadManifestPath(fileName, hash)
+	manifestPath, err := m.ManifestPath(fileName, hash)
 	if err != nil {
 		return nil, "", fmt.Errorf("failed to obtain the path of the downloaded manifest: %w", err)
 	}

--- a/encryption/encryption.go
+++ b/encryption/encryption.go
@@ -185,7 +185,10 @@ func (e *Encryption) CreateEncryptionKey(encryptedFilename string, strings []str
 
 // encryptFile encrypts the file with the given key and writes the encrypted data to a new file
 func (e *Encryption) EncryptFile(filename string, contentData []byte, key []byte) error {
-	f := e.FUInitializer.NewFileutils(e.PartsDir, e.PrefixParts, e.Log)
+	fmt.Println("Parts Dir: ", e.PartsDir)
+	fmt.Println("Prefix Parts: ", e.PrefixParts)
+	fmt.Println("Log: ", e.Log)
+
 	e.Log.Infow("Initializing encryption of manifest file.")
 
 	block, err := aes.NewCipher(key)
@@ -223,13 +226,6 @@ func (e *Encryption) EncryptFile(filename string, contentData []byte, key []byte
 	e.Log.Debugw("File encrypted successfully and saved as:", 
 		"encryptedFilename", filepath.Base(encryptedFilename),
 	)
-
-	if f.PathExists(filename) {
-		err = e.FileOps.Remove(filename)
-		if err != nil {
-			return fmt.Errorf("cannot remove manifest: %w", err)
-		}
-	}
 
 	return nil
 }

--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -57,7 +57,7 @@ func (m *Manifest) SetLogger(log logger.LoggerInterface) {
     m.Log = log
 }
 
-func (m *Manifest) GetDownloadManifestPath(fileName string, hash string) (string, error)  {
+func (m *Manifest) ManifestPath(fileName string, hash string) (string, error)  {
 	// Remove all extensions from the filename, in case file contains multiple extensions or just one
 	f := fileutils.NewFileutils(m.PartsDir, m.PrefixParts, m.Log)
 	fileName = f.RemoveExtensions(fileName)
@@ -80,7 +80,7 @@ func (m *Manifest) DownloadManifestObject(manifest DownloadManifest, fileName st
 	f := fileutils.NewFileutils(m.PartsDir, m.PrefixParts, m.Log)
 	m.Log.Debugw("Initializing Config Directory")
 
-	manifestPath, err := m.GetDownloadManifestPath(fileName, hash)
+	manifestPath, err := m.ManifestPath(fileName, hash)
 	if err != nil {
 		return nil, fmt.Errorf("error getting manifest path: %w", err)
 	}

--- a/manifest/manifest_test.go
+++ b/manifest/manifest_test.go
@@ -1,23 +1,89 @@
 package manifest
 
 import (
+	"crypto/md5"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/campeon23/multi-source-downloader/logger"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestGetDownloadManifestPath(t *testing.T) {
+const (
+	// Let's consider an arbitrary upper limit for our validation
+	// For example, 01-01-3000 @ 00:00:00 UTC in nanoseconds
+	upperLimit int64 = 3250368000000000000
+)
+
+const tempFile = "eample.txt"
+
+// isValidEpochNano validates if the provided epoch timestamp in nanoseconds is reasonable.
+func isValidEpochNano(epochNano int64) bool {
+	return epochNano > 0 && epochNano < upperLimit
+}
+
+func setupTest() (*Manifest, *DownloadManifest, string, string) {
+	l := logger.InitLogger(true)
+	timestamp := 1694268622335882000
+	m := NewManifest("", "", int64(timestamp), l)
+	
+	manifest := DownloadManifest{
+		UUID: "sampleUUID",
+		Version: "sampleVersion",
+		Filename: tempFile,
+		FileHash: "samplehash",
+		URL: "https://example.com/example.txt",
+		Etag: "sampleEtag",
+		HashType: "sampleHashType",
+		PartsDir: "samplePartsDir",
+		PrefixParts: "samplePrefixParts",
+		Size: 100,
+		NumParts: 10,
+		RangeSize: 10,
+		DownloadedParts: []DownloadedPart{
+			{
+				PartNumber: 1,
+				FileHash: "sampleFileHash",
+				Timestamp: 0,
+				PartFile: "samplePartFile",
+			},
+		},
+	}
+
+	fileName := tempFile
+	hash := md5.Sum([]byte("samplehash"))
+
+	return m, &manifest, fileName, hex.EncodeToString(hash[:])
+}
+
+func splitPath(filename string) (string, string, string, string, string, error) {
+	extension := filepath.Ext(filename)
+	filenameBase := filepath.Base(filename)
+	parts := strings.Split(filename[:len(filenameBase)-len(extension)] , "-")
+	if len(parts) != 4 {
+		// Handle the error or unexpected input accordingly
+		return "", "", "", "", "", fmt.Errorf("invalid input")
+	}
+	fmt.Println("Timestamp: ", parts[3])
+	return parts[0], parts[1], parts[2], parts[3], extension, nil
+}
+
+func TestManifestPath(t *testing.T) {
 	assert := assert.New(t)
 
 	l := logger.InitLogger(true)
 	m := NewManifest("", "", 0, l)
 
-	fileName := "example.txt"
+	fileName := tempFile
 	hash := "samplehash"
-	path, err := m.GetDownloadManifestPath(fileName, hash)
+	path, err := m.ManifestPath(fileName, hash)
 
 	// With assert, the checks become more concise and readable
 	assert.Nil(err, "Error getting manifest path")
@@ -25,35 +91,82 @@ func TestGetDownloadManifestPath(t *testing.T) {
 	assert.Equal(".json", filepath.Ext(path), "Manifest file should have .json extension")
 }
 
-func TestSaveAndExtractDownloadManifest(t *testing.T) {
+func TestSaveDownloadManifest(t *testing.T) {
 	assert := assert.New(t)
+	m, manifest, fileName, hash := setupTest()
 
-	l := logger.InitLogger(true)
-	m := NewManifest("", "", 0, l)
-
-	manifest := DownloadManifest{
-		UUID: "sampleUUID",
-		// ... populate other fields
-	}
-	fileName := "example.txt"
-	hash := "samplehash"
-
-	// Test SaveDownloadManifest
-	err := m.SaveDownloadManifest(manifest, fileName, hash)
+	_, err := m.DownloadManifestObject(*manifest, fileName, hash)
 	assert.Nil(err, "Error saving download manifest")
-
-	// Check if the manifest file is created
-	path, _ := m.GetDownloadManifestPath(fileName, hash)
-	_, err = os.Stat(path)
-	assert.False(os.IsNotExist(err), "Manifest file not created")
-
-	// Test ExtractManifestFilePathFileName
-	content, _ := os.ReadFile(path)
-	_, _, _, err = m.ExtractManifestFilePathFileName(fileName, content)
-	assert.Nil(err, "Error extracting manifest file path and file name")
-
-	// Cleanup: Delete the manifest file
-	os.Remove(path)
 }
 
-// Add more tests for other methods.
+func TestEncodeDownloadManifestToJSON(t *testing.T) {
+	assert := assert.New(t)
+	m, manifest, fileName, hash := setupTest()
+
+	contentData, _ := m.DownloadManifestObject(*manifest, fileName, hash)
+	_, err := json.Marshal(contentData)
+	assert.NoError(err, "error encoding manifest JSON")
+}
+
+func TestManifestFileCreation(t *testing.T) {
+	assert := assert.New(t)
+	m, _, filename, hash := setupTest()
+	hashRegex := regexp.MustCompile(`^[a-fA-F0-9]{32}$`)
+
+	path, _ := m.ManifestPath(filename, hash)
+	_, err := os.Stat(path)
+	assert.True(os.IsNotExist(err), "Manifest file not created")
+
+	filenameBase := filepath.Base(path)
+
+	name, typeFile, hash, timestampStr, extension, err := splitPath(filenameBase)
+	assert.NoError(err, "Error splitting path")
+	nameValue := interface{}(name)
+	timestamp, err := strconv.ParseInt(timestampStr, 10, 64)
+	assert.NoError(err, "Error converting timestamp to int64")
+	assert.NoError(err, "Error splitting path")
+	_, ok := nameValue.(string)
+	// Assert that the name is a string
+	assert.True(ok, "Name is not a string")
+	// Assert that the file type is "manifest"
+	assert.Equal("manifest", typeFile)
+	// Assert that the hash is a valid MD5 hash
+	assert.True(hashRegex.MatchString(hash))
+	// Assert that the timestamp is valid
+	assert.True(isValidEpochNano(timestamp))
+	assert.NoError(err, "Error parsing timestamp")
+	// Assert that the extension is ".json"
+	assert.Equal(".json", extension)
+}
+
+func TestReadAndDecodeManifestFile(t *testing.T) {
+	assert := assert.New(t)
+	var decodeData DownloadManifest
+	m, manifest, filename, hash := setupTest()
+
+
+	encodedData, err := json.Marshal(manifest)
+	// Assert that there is no error in encoding the manifest
+	assert.NoError(err, "Error encoding manifest JSON")
+	
+	err = json.Unmarshal(encodedData, &decodeData)
+	// Assert that there is no error in decoding the manifest
+	assert.NoError(err, "error decoding manifest JSON")
+
+	contentData, err := m.DownloadManifestObject(*manifest, filename, hash)
+	assert.NoError(err, "Error obtaining manifest")
+	err = json.Unmarshal(contentData, &decodeData)
+	// Assert that there is no error in decoding the manifest
+	assert.NoError(err, "error decoding manifest JSON")
+}
+
+func TestExtractManifestFilePathFileName(t *testing.T) {
+	assert := assert.New(t)
+	m, manifest, filename, hash := setupTest()
+
+	encodedData, err := m.DownloadManifestObject(*manifest, filename, hash)
+	fmt.Println(encodedData)
+	assert.NoError(err, "Error saving download manifest")
+	_, _, _, err = m.ExtractManifestFilePathFileName(filename, encodedData)
+	assert.NoError(err, "Error extracting manifest file path and file name")
+}


### PR DESCRIPTION
- Removed the File Utils Initializer from EncryptFile() method to enhance unit testing and avoid panics due to null parameters.

- Renamed GetDownloadManifestPath() to ManifestPath() in line with Go naming conventions.

- Updated manifest_test.go to align with the refactored manifest.go logic. With these changes, manifests are now encrypted in memory and subsequently saved to disk, rather than directly created on the disk.