### PR TITLE
Optimize Manifest Decryption Based on Keep Part Files

### DIFF
--- a/multi-source-downloader.go
+++ b/multi-source-downloader.go
@@ -205,14 +205,6 @@ func run(appcfg *localAppConfig){
 		appcfg.Log.Fatalf("Decrypting manifest file: %w", err)
 	}
 
-	if appcfg.KeepParts {
-		// Dump the decrypted content to a JSON file
-		err = os.WriteFile(manifestPath, appcfg.DecryptedContent, 0644)
-		if err != nil {
-			appcfg.Log.Fatalf("Writing decrypted content to JSON file: %w", err)
-		}
-	}
-
 	manifest, outFile, outputPath, err := a.PrepareAssemblyEnviroment(appcfg.OutputFile, appcfg.DecryptedContent)
 	if err != nil {
 		appcfg.Log.Fatalf("Failed to prepare assembly environment: %w", err)


### PR DESCRIPTION
- Removed the decryption logic for the encrypted manifest when the keep part files parameter is activated.

This change streamlines the process by skipping unnecessary decryption steps when retaining downloaded part files is desired.